### PR TITLE
Add how to add Kotlin Style Guide to Editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,5 +16,5 @@ Style guide for Android Apps. Must follow in order to contribute to any of letgo
 ### Apply Kotlin Style-guide
 * On the main menu, choose "File" > "Settings" for Windows and Linux or "Android Studio" > "Preferences" for macOS
 * Go to "Editor" > "Code Style"
-* Go to "Kotlin" > "Set from..." > "Predefined Stlye"
+* Go to "Kotlin" > "Set from..." > "Predefined Style"
 * Select **Kotlin Style guide**

--- a/README.md
+++ b/README.md
@@ -12,3 +12,9 @@ Style guide for Android Apps. Must follow in order to contribute to any of letgo
 * On the main menu, choose "File" > "Settings" for Windows and Linux or "Android Studio" > "Preferences" for macOS
 * Go to "Editor" > "Code Style"
 * Set the field "Right margin (columns):" to **120**
+
+### Apply Kotlin Style-guide
+* On the main menu, choose "File" > "Settings" for Windows and Linux or "Android Studio" > "Preferences" for macOS
+* Go to "Editor" > "Code Style"
+* Go to "Kotlin" > "Set from..." > "Predefined Stlye"
+* Select **Kotlin Style guide**


### PR DESCRIPTION
This PR adds a missing step, how to select kotlin style guide to the Editor-Code Style configuration